### PR TITLE
Allow invalid HTTPS certificates from localhost

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -97,6 +97,18 @@ app.on('ready', function () {
 //     }
 // });
 
+app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+    const isLocal =
+        url.startsWith('https://localhost') ||
+        url.startsWith('https://127.0.0.1');
+    if (isLocal) {
+        event.preventDefault()
+        callback(true)
+    } else {
+        callback(false)
+    }
+})
+
 app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') {
         app.quit();

--- a/electron.js
+++ b/electron.js
@@ -98,9 +98,7 @@ app.on('ready', function () {
 // });
 
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
-    const isLocal =
-        url.startsWith('https://localhost') ||
-        url.startsWith('https://127.0.0.1');
+    const isLocal = url.startsWith('https://127.0.0.1');
     if (isLocal) {
         event.preventDefault()
         callback(true)


### PR DESCRIPTION
Partially fixes #47 

This PR makes Scatter Desktop accept invalid/self-signed HTTPS certificates from locally hosted nodes. This is useful for developers when testing HTTPS-only Dapps locally.