### PR TITLE
fix: issue with identity not being found

### DIFF
--- a/src/services/apps/PermissionService.js
+++ b/src/services/apps/PermissionService.js
@@ -17,7 +17,11 @@ export default class PermissionService {
         const possibleId = permissions.find(x => x.isIdentityPermissionFor(origin));
         if(possibleId){
             let identityRequirements = IdentityRequiredFields.fromPermission(possibleId.identityRequirements);
-            let identity = formatForResult ? possibleId.getIdentity().asOnlyRequiredFields(identityRequirements) : possibleId.getIdentity();
+            let identity = possibleId.getIdentity();
+            if (!identity) return null;
+            if (formatForResult) {
+                identity = identity.asOnlyRequiredFields(identityRequirements);
+            }
             if(!identity) return null;
             identity.accounts = possibleId.getAccounts().map(x => formatForResult ? x.asReturnable() : x);
             return identity;


### PR DESCRIPTION
I had issues with login on my environment, a few of my friends also experienced the same, so we all rolled back to previous version.

I was curios why it isn't working and found out that the issue is pretty simple and easy to fix:
`possibleId.getIdentity()` can return `undefined`. 
In this case `identity.asOnlyRequiredFields(identityRequirements);` fails with ` Cannot read property 'asOnlyRequiredFields' of undefined` which stops the whole log in process. 
