### PR TITLE
Fix: App Names with spaces were unable to continue pairing to Scatter Desktop 12

### DIFF
--- a/electron/services/sockets.js
+++ b/electron/services/sockets.js
@@ -74,7 +74,7 @@ class LowLevelSocketService {
 					if(request.data.payload.origin.toLowerCase() === 'scatter') return killRequest();
 					requestOrigin = request.data.payload.origin;
 
-				} else requestOrigin = request.data.origin.replace(/\s/g, "").trim();
+				} else requestOrigin = request.data.origin = request.data.origin.replace(/\s/g, "").trim();
 
 				if(!origin) origin = requestOrigin;
 				else if(origin && requestOrigin !== origin) return killRequest();

--- a/electron/services/sockets.js
+++ b/electron/services/sockets.js
@@ -29,6 +29,7 @@ class LowLevelSocketService {
 	}
 
 	async emit(origin, id, path, data){
+		origin = origin.replace(/\s/g, "").trim();
 		const socket = this.openConnections[origin+id];
 		return this.emitSocket(socket, path, data);
 	}


### PR DESCRIPTION
sockets.js adjusts the origin or appName by removing all whitespace before setting this.openConnections[origin+id].  Later, during the response for paired, this.emit is called with an origin with whitespace and 'No socket found' is returned.

Changing the origin in emit before searching for the socket will allow the paired handshake to continue.